### PR TITLE
Bind `C-x C-f` to QuickOpen a file and `C-x b` to QuickOpen a buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ Use `Shift+Insert` to paste from clipboard.
 ### File Command
 |Command | Status | Desc |
 |--------|--------|------|
-| `C-o` | OK | Open a file |
-| `C-x b` | OK | QuickOpen a file |
-| `C-x C-f` | OK | Open a working directory |
+| `C-x b` | OK | QuickOpen a buffer |
+| `C-x C-f` | OK | QuickOpen a file |
 | `C-x C-s` | OK | Save |
 | `C-x C-w` | OK | Save as |
 | `C-x i` | - | Insert buffer from file |

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
         "when": "editorTextFocus"
       },{
         "key": "ctrl+x ctrl+f",
-        "command": "workbench.action.files.openFolder"
+        "command": "workbench.action.quickOpen"
       },{
         "key": "ctrl+x ctrl+s",
         "command": "workbench.action.files.save",
@@ -335,7 +335,7 @@
         "command": "workbench.action.toggleSidebarVisibility"
       },{
         "key": "ctrl+x b",
-        "command": "workbench.action.quickOpen"
+        "command": "workbench.action.showAllEditors"
       },{
         "key": "ctrl+x r",
         "command": "emacs.C-x_r",


### PR DESCRIPTION
FYI: `workbench.action.files.openFolder` is not available on Mac.